### PR TITLE
Update migrate.sh for compose v2

### DIFF
--- a/migrate.sh
+++ b/migrate.sh
@@ -2,7 +2,7 @@
 
 echo "Performing migrations. This could take up to 1 minute."
 
-docker-compose exec api tsx packages/backend/src/migrate
+docker compose exec api tsx packages/backend/src/migrate
 
 echo "Migrations complete."
 


### PR DESCRIPTION
Docker Compose V1 is sunset, Compose V2 command is now "docker compose" instead of "docker-compose"